### PR TITLE
chore: update tstyche to v7.2

### DIFF
--- a/__tests__/ts-types/TestComponent.tsx
+++ b/__tests__/ts-types/TestComponent.tsx
@@ -3,9 +3,9 @@ import { expect } from 'tstyche';
 import TestComponent from '../../jest/TestComponent';
 import themed from '../../src';
 
-expect(<TestComponent />).type.toRaiseError(2741);
+expect(TestComponent).type.not.toAcceptProps({})
 
 const Themed = themed(TestComponent, 'Themed');
 
-expect(<Themed badKey="value" />).type.toRaiseError(2322);
-expect(<Themed goodKey="good" />).type.not.toRaiseError();
+expect(Themed).type.not.toAcceptProps({ badKey: "value "})
+expect(Themed).type.toAcceptProps({ goodKey: "value" })

--- a/__tests__/ts-types/TestComponent.tsx
+++ b/__tests__/ts-types/TestComponent.tsx
@@ -7,5 +7,5 @@ expect(TestComponent).type.not.toAcceptProps({})
 
 const Themed = themed(TestComponent, 'Themed');
 
-expect(Themed).type.not.toAcceptProps({ badKey: "value "})
-expect(Themed).type.toAcceptProps({ goodKey: "value" })
+expect(Themed).type.not.toAcceptProps({ badKey: 'value' })
+expect(Themed).type.toAcceptProps({ goodKey: 'value' })

--- a/__tests__/ts-types/TestComponent.tsx
+++ b/__tests__/ts-types/TestComponent.tsx
@@ -1,11 +1,13 @@
+/* eslint-disable react/jsx-filename-extension */
+
 import { expect } from 'tstyche';
 
 import TestComponent from '../../jest/TestComponent';
 import themed from '../../src';
 
-expect(TestComponent).type.not.toAcceptProps({})
+expect(TestComponent).type.not.toAcceptProps({});
 
 const Themed = themed(TestComponent, 'Themed');
 
-expect(Themed).type.not.toAcceptProps({ badKey: 'value' })
-expect(Themed).type.toAcceptProps({ goodKey: 'value' })
+expect(Themed).type.not.toAcceptProps({ badKey: 'value' });
+expect(Themed).type.toAcceptProps({ goodKey: 'value' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "postcss-scss": "^4.0.9",
         "rimraf": "^6.1.3",
         "sass": "^1.100.0",
-        "tstyche": "^7.1.0",
+        "tstyche": "^7.2.0",
         "typed-scss-modules": "^8.1.1",
         "typescript": "^5.9.3"
       },
@@ -12793,16 +12793,16 @@
       "license": "0BSD"
     },
     "node_modules/tstyche": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-7.1.0.tgz",
-      "integrity": "sha512-Ar03KIab85QcPzMRIBrLGqpaKYsnNTbEhhC+wsEGrerSaaLfBDNFDcLtoxEMJHAO/ssjeApAFkjRKUjfxUx4EQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-7.2.0.tgz",
+      "integrity": "sha512-F7Ts325W/X7BsjxmwaLdP+NFTcKWt1h4DfGZO4sY33ERAdDrGIFO8gxjl7I5ZbAb5QxFw/ioTqO3hRRV9lT4GQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "tstyche": "dist/bin.js"
       },
       "engines": {
-        "node": ">=22.12"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "postcss-scss": "^4.0.9",
     "rimraf": "^6.1.3",
     "sass": "^1.100.0",
-    "tstyche": "^7.1.0",
+    "tstyche": "^7.2.0",
     "typed-scss-modules": "^8.1.1",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
This PR updates TSTyche to v7.2. It ships with a reimplemented `.toAcceptProps()` matcher that supports generic JSX components.

This means that now, you can use `.toAcceptProps()` instead of the deprecated `.toRaiseError()`.